### PR TITLE
chore: add PHP 8.2 platform constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,9 @@
 		"audit": {
 			"block-insecure": false
 		},
+		"platform": {
+			"php": "8.2"
+		},
 		"sort-packages": true
 	},
 	"extra": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f8fd2d69ecf17e456ef7a526d7001108",
+    "content-hash": "52283fcabb6104b1dae138e539e58e90",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -609,12 +609,12 @@
             "version": "v7.0.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/firebase/php-jwt.git",
+                "url": "https://github.com/googleapis/php-jwt.git",
                 "reference": "28aa0694bcfdfa5e2959c394d5a1ee7a5083629e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/28aa0694bcfdfa5e2959c394d5a1ee7a5083629e",
+                "url": "https://api.github.com/repos/googleapis/php-jwt/zipball/28aa0694bcfdfa5e2959c394d5a1ee7a5083629e",
                 "reference": "28aa0694bcfdfa5e2959c394d5a1ee7a5083629e",
                 "shasum": ""
             },
@@ -9826,5 +9826,8 @@
         "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
     },
     "platform-dev": {},
+    "platform-overrides": {
+        "php": "8.2"
+    },
     "plugin-api-version": "2.9.0"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,8 @@
 	],
 	"ignorePaths": [
 		"Tests/Acceptance/Fixtures/**"
-	]
+	],
+	"constraints": {
+		"php": ">=8.2"
+	}
 }


### PR DESCRIPTION
## Summary

- Add `platform.php` config to `composer.json` to lock dependency resolution to PHP 8.2
- Add PHP `>=8.2` constraint to `renovate.json` so Renovate respects the minimum PHP version

## Changes

- `composer.json` — Add `config.platform.php: 8.2`
- `composer.lock` — Regenerated with platform constraint
- `renovate.json` — Add `constraints.php: >=8.2`