### PR TITLE
chore(ci): adopt gitleaks and scorecard workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   ter-publish:
     uses: konradmichalik/reusable-github-actions/.github/workflows/release-typo3.yml@main
+    permissions:
+      contents: write
     secrets:
       typo3-api-token: ${{ secrets.TYPO3_API_TOKEN }}
     with:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,17 @@
+name: OpenSSF Scorecard
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+jobs:
+  scorecard:
+    uses: konradmichalik/reusable-github-actions/.github/workflows/scorecard.yml@main
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
+      actions: read

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,12 @@
+name: Security
+on:
+  push:
+    branches:
+      - '**'
+  pull_request: ~
+
+jobs:
+  security:
+    uses: konradmichalik/reusable-github-actions/.github/workflows/security.yml@main
+    permissions:
+      contents: read

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 [![CGL](https://img.shields.io/github/actions/workflow/status/konradmichalik/typo3-dump-server/cgl.yml?label=cgl&logo=github)](https://github.com/konradmichalik/typo3-dump-server/actions/workflows/cgl.yml)
 [![Tests](https://img.shields.io/github/actions/workflow/status/konradmichalik/typo3-dump-server/tests.yml?label=tests&logo=github)](https://github.com/konradmichalik/typo3-dump-server/actions/workflows/tests.yml)
 [![License](https://poser.pugx.org/konradmichalik/typo3-dump-server/license)](LICENSE.md)
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/konradmichalik/typo3-dump-server/badge)](https://securityscorecards.dev/viewer/?uri=github.com/konradmichalik/typo3-dump-server)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![CGL](https://img.shields.io/github/actions/workflow/status/konradmichalik/typo3-dump-server/cgl.yml?label=cgl&logo=github)](https://github.com/konradmichalik/typo3-dump-server/actions/workflows/cgl.yml)
 [![Tests](https://img.shields.io/github/actions/workflow/status/konradmichalik/typo3-dump-server/tests.yml?label=tests&logo=github)](https://github.com/konradmichalik/typo3-dump-server/actions/workflows/tests.yml)
 [![License](https://poser.pugx.org/konradmichalik/typo3-dump-server/license)](LICENSE.md)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/konradmichalik/typo3-dump-server/badge)](https://securityscorecards.dev/viewer/?uri=github.com/konradmichalik/typo3-dump-server)
 
 </div>
 


### PR DESCRIPTION
## Summary
- Add gitleaks secret scanning via the shared reusable workflow
- Add OpenSSF Scorecard supply-chain scoring via the shared reusable workflow
- Grant `contents: write` to the release workflow caller (required once the repo's default token is read-only)

## Context
The central `reusable-github-actions` repository added new `security.yml` (gitleaks) and `scorecard.yml` (OpenSSF Scorecard) reusable workflows, and hardened the required permissions for the release workflow. This PR wires this repository up to consume both new workflows and adds the explicit `contents: write` permission the release job now needs.