### PR TITLE
fix: apply configured path mapping to IDE deep links

### DIFF
--- a/Classes/Command/DumpServerCommand.php
+++ b/Classes/Command/DumpServerCommand.php
@@ -122,6 +122,8 @@ EOF
             return null;
         }
 
-        return new IdeLinkGenerator($ide);
+        [$pathFrom, $pathTo] = EnvironmentHelper::getPathMapping() ?? [null, null];
+
+        return new IdeLinkGenerator($ide, $pathFrom, $pathTo);
     }
 }

--- a/Tests/Unit/Command/DumpServerCommandTest.php
+++ b/Tests/Unit/Command/DumpServerCommandTest.php
@@ -14,10 +14,16 @@ declare(strict_types=1);
 namespace KonradMichalik\Typo3DumpServer\Tests\Unit\Command;
 
 use KonradMichalik\Typo3DumpServer\Command\DumpServerCommand;
+use KonradMichalik\Typo3DumpServer\Utility\IdeLinkGenerator;
 use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
+
+use function assert;
+use function is_array;
+use function is_string;
 
 /**
  * DumpServerCommandTest.
@@ -29,9 +35,45 @@ final class DumpServerCommandTest extends TestCase
 {
     private DumpServerCommand $command;
 
+    private string $originalIdeValue;
+
+    private string $originalPathMapValue;
+
+    private string $originalDdevAppRootValue;
+
     protected function setUp(): void
     {
         $this->command = new DumpServerCommand('server:dump');
+
+        $dumpServerIde = getenv('TYPO3_DUMP_SERVER_IDE');
+        $this->originalIdeValue = is_string($dumpServerIde) ? $dumpServerIde : '';
+
+        $dumpServerPathMap = getenv('TYPO3_DUMP_SERVER_PATH_MAP');
+        $this->originalPathMapValue = is_string($dumpServerPathMap) ? $dumpServerPathMap : '';
+
+        $ddevAppRoot = getenv('DDEV_APPROOT');
+        $this->originalDdevAppRootValue = is_string($ddevAppRoot) ? $ddevAppRoot : '';
+    }
+
+    protected function tearDown(): void
+    {
+        if ('' !== $this->originalIdeValue) {
+            putenv('TYPO3_DUMP_SERVER_IDE='.$this->originalIdeValue);
+        } else {
+            putenv('TYPO3_DUMP_SERVER_IDE');
+        }
+
+        if ('' !== $this->originalPathMapValue) {
+            putenv('TYPO3_DUMP_SERVER_PATH_MAP='.$this->originalPathMapValue);
+        } else {
+            putenv('TYPO3_DUMP_SERVER_PATH_MAP');
+        }
+
+        if ('' !== $this->originalDdevAppRootValue) {
+            putenv('DDEV_APPROOT='.$this->originalDdevAppRootValue);
+        } else {
+            putenv('DDEV_APPROOT');
+        }
     }
 
     public function testCommandHasCorrectName(): void
@@ -64,5 +106,45 @@ final class DumpServerCommandTest extends TestCase
 
         self::assertSame('cli', $formatOption->getDefault());
         self::assertTrue($formatOption->isValueRequired());
+    }
+
+    public function testIdeLinkGeneratorAppliesConfiguredPathMapping(): void
+    {
+        putenv('TYPO3_DUMP_SERVER_IDE=phpstorm');
+        putenv('TYPO3_DUMP_SERVER_PATH_MAP=/var/www/html=/Users/me/Projects');
+        putenv('DDEV_APPROOT');
+
+        $ideLinkGenerator = $this->extractIdeLinkGenerator(new DumpServerCommand('server:dump'));
+
+        self::assertInstanceOf(IdeLinkGenerator::class, $ideLinkGenerator);
+        self::assertSame(
+            'phpstorm://open?file=/Users/me/Projects/test.php&line=42',
+            $ideLinkGenerator->generate('/var/www/html/test.php', 42),
+        );
+    }
+
+    public function testIdeLinkGeneratorWorksWithoutPathMapping(): void
+    {
+        putenv('TYPO3_DUMP_SERVER_IDE=phpstorm');
+        putenv('TYPO3_DUMP_SERVER_PATH_MAP');
+        putenv('DDEV_APPROOT');
+
+        $ideLinkGenerator = $this->extractIdeLinkGenerator(new DumpServerCommand('server:dump'));
+
+        self::assertInstanceOf(IdeLinkGenerator::class, $ideLinkGenerator);
+        self::assertSame(
+            'phpstorm://open?file=/var/www/html/test.php&line=42',
+            $ideLinkGenerator->generate('/var/www/html/test.php', 42),
+        );
+    }
+
+    private function extractIdeLinkGenerator(DumpServerCommand $command): ?IdeLinkGenerator
+    {
+        $descriptors = (new ReflectionProperty($command, 'descriptors'))->getValue($command);
+        assert(is_array($descriptors));
+
+        $ideLinkGenerator = (new ReflectionProperty($descriptors['cli'], 'ideLinkGenerator'))->getValue($descriptors['cli']);
+
+        return $ideLinkGenerator instanceof IdeLinkGenerator ? $ideLinkGenerator : null;
     }
 }


### PR DESCRIPTION
## Summary

- `TYPO3_DUMP_SERVER_PATH_MAP` and the DDEV auto-detection (`DDEV_APPROOT`) were never applied: `DumpServerCommand` constructed the `IdeLinkGenerator` without the path mapping, so IDE deep links from containers pointed to container paths (e.g. `/var/www/html/…`) instead of host paths.
- Wire `EnvironmentHelper::getPathMapping()` into the generator so the documented feature actually takes effect.

## Changes

- `Classes/Command/DumpServerCommand.php` - Pass the resolved path mapping to the `IdeLinkGenerator`
- `Tests/Unit/Command/DumpServerCommandTest.php` - Cover the wiring with and without a configured path mapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dump server IDE links now honor configured path mappings, so generated file paths can match your local project layout.
  * When no path mapping is set, links continue to fall back to the original document root path as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->