### PR TITLE
perf: probe dump server lazily on first dump call

### DIFF
--- a/Classes/Service/DumpHandler.php
+++ b/Classes/Service/DumpHandler.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace KonradMichalik\Typo3DumpServer\Service;
 
+use Closure;
 use KonradMichalik\Typo3DumpServer\Dumper\ContextProvider\Typo3ContextProvider;
 use KonradMichalik\Typo3DumpServer\Event\DumpEvent;
 use KonradMichalik\Typo3DumpServer\Utility\EnvironmentHelper;
@@ -40,18 +41,38 @@ final class DumpHandler
     private static ?EventDispatcherInterface $eventDispatcher = null;
 
     /**
+     * Installs a lazy handler: the dump server is only probed on the first
+     * dump() call, so requests without dumps never touch the socket.
+     *
      * @see https://symfony.com/doc/current/components/var_dumper.html#the-dump-server
      */
     public static function register(): void
     {
-        if (self::isServerAvailable(EnvironmentHelper::getHost())) {
-            self::registerServerHandler();
-        } elseif (self::shouldSuppressDump()) {
-            VarDumper::setHandler(static function (): void {});
-        }
+        VarDumper::setHandler(static fn (mixed $var): mixed => self::dumpWithResolvedHandler($var));
     }
 
-    private static function registerServerHandler(): void
+    private static function dumpWithResolvedHandler(mixed $var): mixed
+    {
+        if (self::isServerAvailable(EnvironmentHelper::getHost())) {
+            $handler = self::createServerHandler();
+            VarDumper::setHandler($handler);
+
+            return $handler($var);
+        }
+
+        if (self::shouldSuppressDump()) {
+            VarDumper::setHandler(static function (): void {});
+
+            return null;
+        }
+
+        // Neither server nor suppression: restore Symfony's default dump behavior
+        VarDumper::setHandler(null);
+
+        return VarDumper::dump($var);
+    }
+
+    private static function createServerHandler(): Closure
     {
         $cloner = new VarCloner();
         $fallbackDumper = in_array(\PHP_SAPI, ['cli', 'phpdbg'], true) ? new CliDumper() : new HtmlDumper();
@@ -61,7 +82,7 @@ final class DumpHandler
             'typo3' => new Typo3ContextProvider(),
         ]);
 
-        VarDumper::setHandler(static function (mixed $var) use ($cloner, $dumper): ?string {
+        return static function (mixed $var) use ($cloner, $dumper): ?string {
             $data = $cloner->cloneVar($var);
             $context = [];
 
@@ -73,7 +94,7 @@ final class DumpHandler
             }
 
             return $dumper->dump($data);
-        });
+        };
     }
 
     private static function shouldSuppressDump(): bool

--- a/Tests/Unit/Service/DumpHandlerTest.php
+++ b/Tests/Unit/Service/DumpHandlerTest.php
@@ -19,6 +19,7 @@ use ReflectionClass;
 use Symfony\Component\VarDumper\VarDumper;
 
 use function is_array;
+use function is_string;
 
 /**
  * DumpHandlerTest.
@@ -28,6 +29,14 @@ use function is_array;
  */
 final class DumpHandlerTest extends TestCase
 {
+    private string $originalHostValue;
+
+    protected function setUp(): void
+    {
+        $dumpServerHost = getenv('TYPO3_DUMP_SERVER_HOST');
+        $this->originalHostValue = is_string($dumpServerHost) ? $dumpServerHost : '';
+    }
+
     protected function tearDown(): void
     {
         // Reset VarDumper handler after each test
@@ -35,16 +44,49 @@ final class DumpHandlerTest extends TestCase
 
         // Reset GLOBALS
         unset($GLOBALS['TYPO3_CONF_VARS']);
+
+        if ('' !== $this->originalHostValue) {
+            putenv('TYPO3_DUMP_SERVER_HOST='.$this->originalHostValue);
+        } else {
+            putenv('TYPO3_DUMP_SERVER_HOST');
+        }
     }
 
-    public function testRegisterWithoutServerSetsNoHandler(): void
+    public function testRegisterInstallsHandlerWithoutConnectingToServer(): void
     {
-        // When server is not available and suppressDump is not set,
-        // the default handler should remain (which will be null in tests)
+        $server = stream_socket_server('tcp://127.0.0.1:0');
+        self::assertNotFalse($server);
+        $address = stream_socket_get_name($server, false);
+        putenv('TYPO3_DUMP_SERVER_HOST=tcp://'.$address);
+
         DumpHandler::register();
 
-        // We can't directly test the handler, but we can verify no exception was thrown
-        self::assertSame(1, 1);
+        $handler = VarDumper::setHandler(null);
+        self::assertNotNull($handler, 'register() should install a dump handler');
+        self::assertFalse(
+            $this->hasPendingConnection($server),
+            'register() must not connect to the dump server',
+        );
+
+        fclose($server);
+    }
+
+    public function testFirstDumpConnectsToServer(): void
+    {
+        $server = stream_socket_server('tcp://127.0.0.1:0');
+        self::assertNotFalse($server);
+        $address = stream_socket_get_name($server, false);
+        putenv('TYPO3_DUMP_SERVER_HOST=tcp://'.$address);
+
+        DumpHandler::register();
+        dump('test');
+
+        self::assertTrue(
+            $this->hasPendingConnection($server),
+            'The first dump() call should connect to the dump server',
+        );
+
+        fclose($server);
     }
 
     public function testRegisterWithSuppressDumpSetsEmptyHandler(): void
@@ -60,6 +102,7 @@ final class DumpHandlerTest extends TestCase
             $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['typo3_dump_server'] = [];
         }
         $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['typo3_dump_server']['suppressDump'] = true;
+        putenv('TYPO3_DUMP_SERVER_HOST=tcp://127.0.0.1:59999');
 
         DumpHandler::register();
 
@@ -196,5 +239,17 @@ final class DumpHandlerTest extends TestCase
         // Reset and test with non-array extension config
         $GLOBALS['TYPO3_CONF_VARS'] = ['EXTENSIONS' => ['typo3_dump_server' => 'not-an-array']];
         self::assertFalse($method->invoke(null));
+    }
+
+    /**
+     * @param resource $server
+     */
+    private function hasPendingConnection($server): bool
+    {
+        $read = [$server];
+        $write = [];
+        $except = [];
+
+        return stream_select($read, $write, $except, 0, 50000) > 0;
     }
 }


### PR DESCRIPTION
## Summary

- `DumpHandler::register()` opened a TCP probe connection (`fsockopen`, 0.5s timeout) on **every** TYPO3 request — frontend, backend and CLI — even when the request never called `dump()`. With an unreachable or filtered host (e.g. a remote `TYPO3_DUMP_SERVER_HOST` or a firewall that drops packets), this blocked every request for up to 500 ms.
- `register()` now only installs a lightweight lazy handler. The first `dump()` call probes the server and swaps in the resolved handler (server dumper, no-op for `suppressDump`, or Symfony's default inline output). Requests without dumps never touch the socket.
- Behavior of all three resolution paths is unchanged; only the probe timing moved.

## Changes

- `Classes/Service/DumpHandler.php` - Install a lazy handler in `register()`; resolve server availability, suppression or default fallback on the first `dump()` call
- `Tests/Unit/Service/DumpHandlerTest.php` - Assert via a real listening socket that `register()` does not connect and the first `dump()` does; make the suppression test deterministic with an explicit unreachable host

🤖 Generated with [Claude Code](https://claude.com/claude-code)