### PR TITLE
fix: reject script-executing schemes in HTML descriptor links

### DIFF
--- a/Classes/Command/Descriptor/Typo3HtmlDescriptor.php
+++ b/Classes/Command/Descriptor/Typo3HtmlDescriptor.php
@@ -25,15 +25,19 @@ use function date;
 use function dirname;
 use function file_get_contents;
 use function htmlspecialchars;
+use function in_array;
 use function is_array;
 use function is_float;
 use function is_int;
 use function is_string;
+use function parse_url;
 use function random_bytes;
 use function sprintf;
+use function strtolower;
 
 use const ENT_QUOTES;
 use const ENT_SUBSTITUTE;
+use const PHP_URL_SCHEME;
 
 /**
  * Typo3HtmlDescriptor.
@@ -43,6 +47,11 @@ use const ENT_SUBSTITUTE;
  */
 final class Typo3HtmlDescriptor implements DumpDescriptorInterface
 {
+    /**
+     * Schemes a browser executes as script when used as link target.
+     */
+    private const UNSAFE_LINK_SCHEMES = ['javascript', 'data', 'vbscript'];
+
     private bool $initialized = false;
 
     public function __construct(
@@ -118,10 +127,7 @@ final class Typo3HtmlDescriptor implements DumpDescriptorInterface
     private function resolveTitle(array $context): string
     {
         if (isset($context['request']) && is_array($context['request'])) {
-            $method = is_string($context['request']['method'] ?? null) ? $context['request']['method'] : '';
-            $uri = is_string($context['request']['uri'] ?? null) ? $context['request']['uri'] : '';
-
-            return sprintf('<code>%s</code> <a href="%s">%s</a>', $this->escape($method), $this->escape($uri), $this->escape($uri));
+            return $this->resolveRequestTitle($context['request']);
         }
 
         if (isset($context['cli']) && is_array($context['cli'])) {
@@ -133,6 +139,22 @@ final class Typo3HtmlDescriptor implements DumpDescriptorInterface
         }
 
         return '-';
+    }
+
+    /**
+     * @param array<mixed, mixed> $request
+     */
+    private function resolveRequestTitle(array $request): string
+    {
+        $method = is_string($request['method'] ?? null) ? $request['method'] : '';
+        $uri = is_string($request['uri'] ?? null) ? $request['uri'] : '';
+        $safeUri = $this->escape($uri);
+
+        if ($this->hasSafeLinkScheme($uri)) {
+            $safeUri = sprintf('<a href="%s">%s</a>', $safeUri, $safeUri);
+        }
+
+        return sprintf('<code>%s</code> %s', $this->escape($method), $safeUri);
     }
 
     /**
@@ -246,7 +268,14 @@ final class Typo3HtmlDescriptor implements DumpDescriptorInterface
 
         $fileLink = $source['file_link'] ?? null;
 
-        return is_string($fileLink) ? $fileLink : null;
+        return is_string($fileLink) && $this->hasSafeLinkScheme($fileLink) ? $fileLink : null;
+    }
+
+    private function hasSafeLinkScheme(string $url): bool
+    {
+        $scheme = parse_url($url, PHP_URL_SCHEME);
+
+        return is_string($scheme) && !in_array(strtolower($scheme), self::UNSAFE_LINK_SCHEMES, true);
     }
 
     /**

--- a/Tests/Unit/Command/Descriptor/Typo3HtmlDescriptorTest.php
+++ b/Tests/Unit/Command/Descriptor/Typo3HtmlDescriptorTest.php
@@ -108,4 +108,96 @@ final class Typo3HtmlDescriptorTest extends TestCase
 
         self::assertStringContainsString('TestController.php on line 42', $result);
     }
+
+    #[Test]
+    public function describeRendersHttpRequestUriAsLink(): void
+    {
+        $result = $this->describeWithContext([
+            'timestamp' => microtime(true),
+            'request' => [
+                'method' => 'GET',
+                'uri' => 'https://example.com/page',
+            ],
+        ]);
+
+        self::assertStringContainsString('<a href="https://example.com/page">', $result);
+    }
+
+    #[Test]
+    public function describeDoesNotLinkRequestUriWithUnsafeScheme(): void
+    {
+        $result = $this->describeWithContext([
+            'timestamp' => microtime(true),
+            'request' => [
+                'method' => 'GET',
+                'uri' => 'javascript:alert(1)',
+            ],
+        ]);
+
+        self::assertStringNotContainsString('href=', $result);
+        self::assertStringContainsString('javascript:alert(1)', $result);
+    }
+
+    #[Test]
+    public function describeUsesFileLinkFromContext(): void
+    {
+        $result = $this->describeWithContext([
+            'timestamp' => microtime(true),
+            'source' => [
+                'name' => 'TestController.php',
+                'file' => '/var/www/html/Classes/Controller/TestController.php',
+                'line' => 42,
+                'file_link' => 'phpstorm://open?file=/var/www/html/Classes/Controller/TestController.php&line=42',
+            ],
+        ]);
+
+        self::assertStringContainsString('<a href="phpstorm://open?file=', $result);
+    }
+
+    #[Test]
+    public function describeIgnoresFileLinkWithUnsafeScheme(): void
+    {
+        $result = $this->describeWithContext([
+            'timestamp' => microtime(true),
+            'source' => [
+                'name' => 'TestController.php',
+                'file' => '/var/www/html/Classes/Controller/TestController.php',
+                'line' => 42,
+                'file_link' => 'javascript:alert(1)',
+            ],
+        ]);
+
+        self::assertStringNotContainsString('href=', $result);
+        self::assertStringContainsString('TestController.php on line 42', $result);
+    }
+
+    #[Test]
+    public function describeIgnoresFileLinkWithoutScheme(): void
+    {
+        $result = $this->describeWithContext([
+            'timestamp' => microtime(true),
+            'source' => [
+                'name' => 'TestController.php',
+                'file' => '/var/www/html/Classes/Controller/TestController.php',
+                'line' => 42,
+                'file_link' => "java\tscript:alert(1)",
+            ],
+        ]);
+
+        self::assertStringNotContainsString('href=', $result);
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    private function describeWithContext(array $context): string
+    {
+        $descriptor = new Typo3HtmlDescriptor(new HtmlDumper());
+        $output = new BufferedOutput();
+        $data = (new VarCloner())->cloneVar('test');
+
+        $descriptor->describe($output, $data, $context, 1);
+
+        return $output->fetch();
+    }
 }


### PR DESCRIPTION
## Summary

- The HTML descriptor HTML-escaped all context values but used them as link targets without scheme validation. A malicious local client on the (unauthenticated) dump server socket could send a crafted `request.uri` or `source.file_link` such as `javascript:alert(1)`; clicking the link in the generated `dump.html` would execute script.
- Link targets now require a parseable, non-empty URL scheme that is not script-executing (`javascript`, `data`, `vbscript`). Requiring a valid scheme also blocks obfuscation bypasses like `java\tscript:`. Unsafe URIs are still displayed as escaped text, just not linked; IDE protocol handlers (`phpstorm://`, `vscode://`, custom schemes) keep working.
- Extracted `resolveRequestTitle()` to keep the class within the PHPStan cognitive-complexity budget.

## Changes

- `Classes/Command/Descriptor/Typo3HtmlDescriptor.php` - Validate link scheme for the request URI title link and the `file_link` from client context
- `Tests/Unit/Command/Descriptor/Typo3HtmlDescriptorTest.php` - Cover safe/unsafe/scheme-less link targets for both link locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)