### PR TITLE
fix: keep dump working when a DumpEvent listener throws

### DIFF
--- a/Classes/Service/DumpHandler.php
+++ b/Classes/Service/DumpHandler.php
@@ -89,8 +89,11 @@ final class DumpHandler
             // Dispatch PSR-14 event with original variable
             $eventDispatcher = self::getEventDispatcher();
             if (null !== $eventDispatcher) {
-                $event = new DumpEvent($var, $context);
-                $eventDispatcher->dispatch($event);
+                try {
+                    $eventDispatcher->dispatch(new DumpEvent($var, $context));
+                } catch (Throwable) {
+                    // A faulty listener must never break the dump itself
+                }
             }
 
             return $dumper->dump($data);

--- a/Tests/Unit/Service/DumpHandlerTest.php
+++ b/Tests/Unit/Service/DumpHandlerTest.php
@@ -15,7 +15,10 @@ namespace KonradMichalik\Typo3DumpServer\Tests\Unit\Service;
 
 use KonradMichalik\Typo3DumpServer\Service\DumpHandler;
 use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use ReflectionClass;
+use ReflectionProperty;
+use RuntimeException;
 use Symfony\Component\VarDumper\VarDumper;
 
 use function is_array;
@@ -44,6 +47,9 @@ final class DumpHandlerTest extends TestCase
 
         // Reset GLOBALS
         unset($GLOBALS['TYPO3_CONF_VARS']);
+
+        // Reset cached event dispatcher
+        (new ReflectionProperty(DumpHandler::class, 'eventDispatcher'))->setValue(null, null);
 
         if ('' !== $this->originalHostValue) {
             putenv('TYPO3_DUMP_SERVER_HOST='.$this->originalHostValue);
@@ -84,6 +90,32 @@ final class DumpHandlerTest extends TestCase
         self::assertTrue(
             $this->hasPendingConnection($server),
             'The first dump() call should connect to the dump server',
+        );
+
+        fclose($server);
+    }
+
+    public function testDumpStillReachesServerWhenEventListenerThrows(): void
+    {
+        $server = stream_socket_server('tcp://127.0.0.1:0');
+        self::assertNotFalse($server);
+        $address = stream_socket_get_name($server, false);
+        putenv('TYPO3_DUMP_SERVER_HOST=tcp://'.$address);
+
+        $throwingDispatcher = new class implements EventDispatcherInterface {
+            public function dispatch(object $event): object
+            {
+                throw new RuntimeException('listener failure');
+            }
+        };
+        (new ReflectionProperty(DumpHandler::class, 'eventDispatcher'))->setValue(null, $throwingDispatcher);
+
+        DumpHandler::register();
+        dump('test');
+
+        self::assertTrue(
+            $this->hasPendingConnection($server),
+            'A throwing event listener must not prevent the dump from reaching the server',
         );
 
         fclose($server);

--- a/Tests/Unit/Service/DumpHandlerTest.php
+++ b/Tests/Unit/Service/DumpHandlerTest.php
@@ -105,7 +105,7 @@ final class DumpHandlerTest extends TestCase
         $throwingDispatcher = new class implements EventDispatcherInterface {
             public function dispatch(object $event): object
             {
-                throw new RuntimeException('listener failure');
+                throw new RuntimeException('listener failure', 2834025464);
             }
         };
         (new ReflectionProperty(DumpHandler::class, 'eventDispatcher'))->setValue(null, $throwingDispatcher);


### PR DESCRIPTION
> **Stacked on #56** — targets `perf/lazy-dump-server-probe` because both change the same handler closure; GitHub retargets this PR to `main` automatically once #56 is merged.

## Summary

- The PSR-14 `DumpEvent` dispatch inside the dump handler was unguarded: a single faulty event listener turned every `dump()` call into an unhandled exception and broke the whole request.
- The dispatch is now wrapped in a `try`/`catch` so a throwing listener can never prevent the dump from reaching the server.

## Changes

- `Classes/Service/DumpHandler.php` - Guard the `DumpEvent` dispatch against listener exceptions
- `Tests/Unit/Service/DumpHandlerTest.php` - Inject a throwing dispatcher and assert the dump still reaches the server; reset the cached dispatcher between tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)