### PR TITLE
docs: document security model of the unauthenticated dump server socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ vendor/bin/typo3 server:dump --format=html > dump.html
 > [!NOTE]
 > The dump server will be available at `tcp://127.0.0.1:9912` by default. Use the environment variable `TYPO3_DUMP_SERVER_HOST` to change the host.
 
+> [!WARNING]
+> The dump server protocol is unauthenticated and unencrypted, and dumps often contain sensitive data (credentials, session data, personal data). Keep the server bound to a loopback address (`127.0.0.1`) — never expose it via `0.0.0.0` or a public interface. Install the extension as a dev dependency (`composer require --dev`) so it is not deployed to production systems.
+
 ### IDE Deep Links
 
 Click on source file paths in the dump output to open them directly in your IDE. Configure the IDE via environment variable:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,3 +4,11 @@
 > **Please avoid using GitHub issues to report security vulnerabilities.**
 
 If you have found a potential security flaw, please reach out directly to the [TYPO3 Security Team](https://typo3.community/contribute/teams-committees/security). For additional information and guidelines, you can also check out [TYPO3's Security Policy](https://github.com/TYPO3/typo3/blob/main/SECURITY.md).
+
+## Security Model
+
+This extension is a **development tool**. The underlying Symfony Var Dump Server protocol is unauthenticated and unencrypted:
+
+- Any local process can connect to the dump server socket and send payloads, or bind the port first and receive all dump output. Dumps frequently contain credentials, session data, or personal data — on shared or multi-user hosts, treat the socket as readable by every local user.
+- Keep `TYPO3_DUMP_SERVER_HOST` on a loopback address (default: `tcp://127.0.0.1:9912`). Never bind the server to `0.0.0.0` or a public interface.
+- Install the extension with `composer require --dev` so it never ships to production. If it does end up on a production system, enable the `suppressDump` extension setting to prevent dump output from leaking into HTTP responses while the server is not running.


### PR DESCRIPTION
## Summary

- The Symfony Var Dump Server protocol is unauthenticated and unencrypted; dumps often carry sensitive data. Neither the README nor the security policy mentioned the resulting operational constraints.
- Add a warning to the README (keep the server on loopback, never bind `0.0.0.0`, install with `--dev`) and a "Security Model" section to `SECURITY.md` covering the local attack surface on shared hosts and the `suppressDump` safety net for production systems.

## Changes

- `README.md` - Warning block next to the `TYPO3_DUMP_SERVER_HOST` note
- `SECURITY.md` - New "Security Model" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)