### PR TITLE
test: reach full unit test coverage using pcov

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -15,7 +15,7 @@ additional_fqdns: []
 database:
   type: mariadb
   version: "10.11"
-webimage_extra_packages: [libxml2-utils]
+webimage_extra_packages: [libxml2-utils, php8.2-pcov]
 use_dns_when_possible: true
 corepack_enable: false
 hooks:

--- a/Classes/Command/DumpServerCommand.php
+++ b/Classes/Command/DumpServerCommand.php
@@ -89,6 +89,9 @@ EOF
             throw new InvalidArgumentException(sprintf('Unsupported format "%s".', $format), 8369534570);
         }
 
+        // @codeCoverageIgnoreStart
+        // DumpServer::listen() blocks until the process is killed (CONTROL-C), so this
+        // path cannot be exercised by an automated test without hanging the test run.
         $server = new DumpServer(EnvironmentHelper::getHost());
 
         $errorIo = $io->getErrorStyle();
@@ -104,6 +107,7 @@ EOF
         });
 
         return Command::SUCCESS;
+        // @codeCoverageIgnoreEnd
     }
 
     /**

--- a/Tests/Unit/Command/Descriptor/Typo3CliDescriptorTest.php
+++ b/Tests/Unit/Command/Descriptor/Typo3CliDescriptorTest.php
@@ -111,4 +111,90 @@ final class Typo3CliDescriptorTest extends TestCase
         self::assertStringContainsString('TestController.php', $result);
         self::assertStringContainsString('42', $result);
     }
+
+    #[Test]
+    public function describeDefaultsTimestampWhenMissing(): void
+    {
+        $descriptor = new Typo3CliDescriptor(new CliDumper());
+        $output = new BufferedOutput();
+        $cloner = new VarCloner();
+        $data = $cloner->cloneVar('test');
+
+        $descriptor->describe($output, $data, [], 1);
+        $result = $output->fetch();
+
+        self::assertStringContainsString('1970', $result);
+    }
+
+    #[Test]
+    public function describeOutputsHttpRequestContextWithController(): void
+    {
+        $descriptor = new Typo3CliDescriptor(new CliDumper());
+        $output = new BufferedOutput();
+        $cloner = new VarCloner();
+        $data = $cloner->cloneVar('test');
+
+        $context = [
+            'timestamp' => microtime(true),
+            'request' => [
+                'identifier' => 'req-1',
+                'method' => 'GET',
+                'uri' => '/some/path',
+                'controller' => $cloner->cloneVar('SomeController::action'),
+            ],
+        ];
+
+        $descriptor->describe($output, $data, $context, 1);
+        $result = $output->fetch();
+
+        self::assertStringContainsString('GET /some/path', $result);
+        self::assertStringContainsString('controller', $result);
+    }
+
+    #[Test]
+    public function describeOutputsCliContextWithoutRequest(): void
+    {
+        $descriptor = new Typo3CliDescriptor(new CliDumper());
+        $output = new BufferedOutput();
+        $cloner = new VarCloner();
+        $data = $cloner->cloneVar('test');
+
+        $context = [
+            'timestamp' => microtime(true),
+            'cli' => [
+                'identifier' => 'cli-1',
+                'command_line' => 'bin/console some:command',
+            ],
+        ];
+
+        $descriptor->describe($output, $data, $context, 1);
+        $result = $output->fetch();
+
+        self::assertStringContainsString('bin/console some:command', $result);
+    }
+
+    #[Test]
+    public function describeUsesFileRelativeOverFile(): void
+    {
+        $descriptor = new Typo3CliDescriptor(new CliDumper());
+        $output = new BufferedOutput();
+        $cloner = new VarCloner();
+        $data = $cloner->cloneVar('test');
+
+        $context = [
+            'timestamp' => microtime(true),
+            'source' => [
+                'name' => 'TestController.php',
+                'file' => '/var/www/html/Classes/Controller/TestController.php',
+                'file_relative' => 'Classes/Controller/TestController.php',
+                'line' => 42,
+            ],
+        ];
+
+        $descriptor->describe($output, $data, $context, 1);
+        $result = $output->fetch();
+
+        self::assertStringContainsString('Classes/Controller/TestController.php', $result);
+        self::assertStringNotContainsString('/var/www/html/Classes', $result);
+    }
 }

--- a/Tests/Unit/Command/Descriptor/Typo3HtmlDescriptorTest.php
+++ b/Tests/Unit/Command/Descriptor/Typo3HtmlDescriptorTest.php
@@ -22,6 +22,8 @@ use Symfony\Component\VarDumper\Cloner\VarCloner;
 use Symfony\Component\VarDumper\Command\Descriptor\DumpDescriptorInterface;
 use Symfony\Component\VarDumper\Dumper\HtmlDumper;
 
+use function strlen;
+
 /**
  * Typo3HtmlDescriptorTest.
  *
@@ -185,6 +187,71 @@ final class Typo3HtmlDescriptorTest extends TestCase
         ]);
 
         self::assertStringNotContainsString('href=', $result);
+    }
+
+    #[Test]
+    public function describeOnlyRendersStylesOnFirstCall(): void
+    {
+        $descriptor = new Typo3HtmlDescriptor(new HtmlDumper());
+        $output = new BufferedOutput();
+        $data = (new VarCloner())->cloneVar('test');
+        $context = ['timestamp' => microtime(true)];
+
+        $descriptor->describe($output, $data, $context, 1);
+        $firstCall = $output->fetch();
+
+        $descriptor->describe($output, $data, $context, 2);
+        $secondCall = $output->fetch();
+
+        // Only the first call injects the shared htmlDescriptor.css/js assets,
+        // so its output is necessarily larger than a repeat call's.
+        self::assertGreaterThan(strlen($secondCall), strlen($firstCall));
+    }
+
+    #[Test]
+    public function describeOutputsCliTitleAndDedupIdentifierWithoutRequest(): void
+    {
+        $result = $this->describeWithContext([
+            'timestamp' => microtime(true),
+            'cli' => [
+                'identifier' => 'cli-1',
+                'command_line' => 'bin/console some:command',
+            ],
+        ]);
+
+        self::assertStringContainsString('bin/console some:command', $result);
+        self::assertStringContainsString('data-dedup-id="cli-1"', $result);
+    }
+
+    #[Test]
+    public function describeDefaultsCliTitleWhenCommandLineIsMissing(): void
+    {
+        $result = $this->describeWithContext([
+            'timestamp' => microtime(true),
+            'cli' => [
+                'identifier' => 'cli-2',
+            ],
+        ]);
+
+        self::assertStringContainsString('<code>$ </code>', $result);
+    }
+
+    #[Test]
+    public function describeOutputsControllerAndDedupIdentifierFromRequest(): void
+    {
+        $cloner = new VarCloner();
+        $result = $this->describeWithContext([
+            'timestamp' => microtime(true),
+            'request' => [
+                'identifier' => 'req-1',
+                'method' => 'GET',
+                'uri' => '/some/path',
+                'controller' => $cloner->cloneVar('SomeController::action'),
+            ],
+        ]);
+
+        self::assertStringContainsString('data-dedup-id="req-1"', $result);
+        self::assertStringContainsString('dumped-tag', $result);
     }
 
     /**

--- a/Tests/Unit/Command/DumpServerCommandTest.php
+++ b/Tests/Unit/Command/DumpServerCommandTest.php
@@ -16,9 +16,10 @@ namespace KonradMichalik\Typo3DumpServer\Tests\Unit\Command;
 use KonradMichalik\Typo3DumpServer\Command\DumpServerCommand;
 use KonradMichalik\Typo3DumpServer\Utility\IdeLinkGenerator;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
 use ReflectionProperty;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
-use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\{ArrayInput};
 use Symfony\Component\Console\Output\BufferedOutput;
 
 use function assert;
@@ -97,6 +98,24 @@ final class DumpServerCommandTest extends TestCase
         $this->expectExceptionMessage('Unsupported format "invalid".');
 
         $this->command->run($input, $output);
+    }
+
+    public function testNonStringFormatOptionThrowsException(): void
+    {
+        $input = new class(['--format' => 'cli']) extends ArrayInput {
+            public function getOption(string $name): mixed
+            {
+                return 'format' === $name ? true : parent::getOption($name);
+            }
+        };
+        $output = new BufferedOutput();
+
+        $method = new ReflectionMethod($this->command, 'execute');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Format option must be a string.');
+
+        $method->invoke($this->command, $input, $output);
     }
 
     public function testValidFormatsAreAccepted(): void

--- a/Tests/Unit/Command/DumpServerCommandTest.php
+++ b/Tests/Unit/Command/DumpServerCommandTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 use ReflectionProperty;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
-use Symfony\Component\Console\Input\{ArrayInput};
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 
 use function assert;

--- a/Tests/Unit/Service/DumpHandlerTest.php
+++ b/Tests/Unit/Service/DumpHandlerTest.php
@@ -146,6 +146,17 @@ final class DumpHandlerTest extends TestCase
         self::assertSame('', $output);
     }
 
+    public function testDumpFallsBackToDefaultHandlerWhenServerUnavailableAndNotSuppressed(): void
+    {
+        putenv('TYPO3_DUMP_SERVER_HOST=tcp://127.0.0.1:59999');
+
+        DumpHandler::register();
+
+        $result = dump('fallback-value');
+
+        self::assertSame('fallback-value', $result);
+    }
+
     public function testIsServerAvailableReturnsFalseForInvalidHost(): void
     {
         $reflection = new ReflectionClass(DumpHandler::class);

--- a/Tests/Unit/ViewHelpers/DumpViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/DumpViewHelperTest.php
@@ -15,6 +15,7 @@ namespace KonradMichalik\Typo3DumpServer\Tests\Unit\ViewHelpers;
 
 use KonradMichalik\Typo3DumpServer\ViewHelpers\DumpViewHelper;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\VarDumper\VarDumper;
 
 /**
  * DumpViewHelperTest.
@@ -40,5 +41,43 @@ final class DumpViewHelperTest extends TestCase
     public function testViewHelperExtendsAbstractViewHelper(): void
     {
         self::assertInstanceOf(\TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper::class, $this->viewHelper);
+    }
+
+    public function testRenderReturnsStringResultFromRenderChildren(): void
+    {
+        $viewHelper = new class extends DumpViewHelper {
+            public function renderChildren(): mixed
+            {
+                return 'child content';
+            }
+        };
+
+        VarDumper::setHandler(static function (): void {});
+        try {
+            $result = $viewHelper->render();
+        } finally {
+            VarDumper::setHandler(null);
+        }
+
+        self::assertSame('child content', $result);
+    }
+
+    public function testRenderReturnsEmptyStringForNonStringResult(): void
+    {
+        $viewHelper = new class extends DumpViewHelper {
+            public function renderChildren(): mixed
+            {
+                return ['not', 'a', 'string'];
+            }
+        };
+
+        VarDumper::setHandler(static function (): void {});
+        try {
+            $result = $viewHelper->render();
+        } finally {
+            VarDumper::setHandler(null);
+        }
+
+        self::assertSame('', $result);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -73,6 +73,6 @@
 		"docs:cleanup": "rm -rf .Build/docs",
 		"docs:open": "open .Build/docs/Index.html",
 		"test": "@test:coverage --no-coverage",
-		"test:coverage": "XDEBUG_MODE=coverage phpunit -c phpunit.xml"
+		"test:coverage": "phpunit -c phpunit.xml"
 	}
 }


### PR DESCRIPTION
## Summary

- Switch coverage collection from Xdebug to the PCOV extension so `composer test:coverage` no longer requires toggling Xdebug in DDEV
- Exclude the dump-server's blocking `listen()` loop from coverage, since it cannot be exercised by an automated test without hanging the run
- Add unit tests for previously uncovered branches, bringing line/method/class coverage to 100%

## Changes

- `.ddev/config.yaml` - add `php8.2-pcov` to `webimage_extra_packages`
- `composer.json` - drop `XDEBUG_MODE=coverage` from the `test:coverage` script
- `Classes/Command/DumpServerCommand.php` - mark the unreachable server start/listen block with `@codeCoverageIgnore`
- `Tests/Unit/Command/DumpServerCommandTest.php` - cover the non-string `format` option branch
- `Tests/Unit/Command/Descriptor/Typo3CliDescriptorTest.php` - cover request/cli context branches and the `file_relative` fallback
- `Tests/Unit/Command/Descriptor/Typo3HtmlDescriptorTest.php` - cover cli title/dedup branches, controller rendering, and the one-time asset injection guard
- `Tests/Unit/Service/DumpHandlerTest.php` - cover the fallback path when the dump server is unavailable and suppression is disabled
- `Tests/Unit/ViewHelpers/DumpViewHelperTest.php` - cover `render()`'s string and non-string result branches

## Test plan

- [x] `ddev composer test:coverage` - 92 tests passing, 100% line/method/class coverage
- [x] `ddev composer cgl -- sca:php` - PHPStan level max, no errors
- [x] `ddev composer cgl -- lint:php` - PHP CS Fixer clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved output details in dump-related views, including clearer handling of request, CLI, and source-location information.
  * Added broader test coverage for dump formatting and display behavior.

* **Bug Fixes**
  * Fixed fallback behavior when the dump server is unavailable, so output still appears normally.
  * Ensured invalid format settings are handled with a clear error.
  * Adjusted coverage support and local environment setup for more reliable testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->